### PR TITLE
Add interactive portfolio example

### DIFF
--- a/portfolio/README.md
+++ b/portfolio/README.md
@@ -1,0 +1,17 @@
+# Interactive Portfolio
+
+This example shows a simple interactive portfolio for a Codecademy graduate in Full Stack, AI Engineering, and Data Analytics.
+
+The site uses [A-Frame](https://aframe.io/) to create a small 3D desert scene inspired by Arizona. It includes basic cactus shapes and a placeholder cowboy model. The slider in the top left lets visitors zoom in and out of the scene, giving a playful way to explore the portfolio page.
+
+## Running Locally
+
+Just open `index.html` in a modern web browser. No build step is required.
+
+## Customizing the Scene
+
+- Replace the placeholder GLTF model URL with your own cowboy model.
+- Add more 3D objects such as rocks, additional cacti, or even mountains by inserting more A-Frame primitives or GLTF models.
+- Edit the HTML to showcase your projects and achievements within the 3D space.
+
+Feel free to extend this with additional interactivity using JavaScript or A-Frame components.

--- a/portfolio/index.html
+++ b/portfolio/index.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Codecademy Graduate Portfolio</title>
+    <script src="https://aframe.io/releases/1.5.0/aframe.min.js"></script>
+    <style>
+        body, html { margin: 0; padding: 0; height: 100%; overflow: hidden; }
+        #zoomSlider { position: absolute; top: 10px; left: 10px; z-index: 1; }
+    </style>
+</head>
+<body>
+    <input type="range" id="zoomSlider" min="0.5" max="2" step="0.1" value="1">
+    <a-scene embedded id="scene">
+        <a-sky color="#ECECEC"></a-sky>
+        <a-plane color="#EDC9Af" rotation="-90 0 0" width="50" height="50"></a-plane>
+
+        <!-- Simple cactus using primitives -->
+        <a-cylinder position="-2 0.5 -3" radius="0.2" height="1" color="#228B22"></a-cylinder>
+        <a-box position="-2 1.2 -3" depth="0.3" height="0.5" width="0.3" color="#228B22"></a-box>
+        <a-cylinder position="-1 0.5 -4" radius="0.2" height="1" color="#228B22"></a-cylinder>
+
+        <!-- Cowboy model placeholder -->
+        <a-entity position="1 0 -3" gltf-model="https://cdn.aframe.io/examples/ui-tour/CesiumMan.gltf" scale="1 1 1"></a-entity>
+    </a-scene>
+
+    <script>
+      const slider = document.getElementById('zoomSlider');
+      slider.addEventListener('input', (e) => {
+          const scene = document.getElementById('scene');
+          scene.style.transform = `scale(${e.target.value})`;
+      });
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add simple 3D portfolio site using A-Frame
- include README describing how to run and customize the portfolio

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687f1d83ce90832ea623eab41b63ebc9